### PR TITLE
Allow nil to be passed to Stop

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -109,7 +109,7 @@ func (e *Entry) Trace(msg string) *Entry {
 // Stop should be used with Trace, to fire off the completion message. When
 // an `err` is passed the "error" field is set, and the log level is error.
 func (e *Entry) Stop(err *error) {
-	if *err == nil {
+	if err == nil || *err == nil {
 		e.WithField("duration", time.Since(e.start)).Info(e.Message)
 	} else {
 		e.WithField("duration", time.Since(e.start)).WithError(*err).Error(e.Message)

--- a/logger_test.go
+++ b/logger_test.go
@@ -147,6 +147,36 @@ func TestLogger_Trace_error(t *testing.T) {
 	}
 }
 
+func TestLogger_Trace_nil(t *testing.T) {
+	h := memory.New()
+
+	l := &log.Logger{
+		Handler: h,
+		Level:   log.InfoLevel,
+	}
+
+	func() {
+		defer l.WithField("file", "sloth.png").Trace("upload").Stop(nil)
+	}()
+
+	assert.Equal(t, 2, len(h.Entries))
+
+	{
+		e := h.Entries[0]
+		assert.Equal(t, e.Message, "upload")
+		assert.Equal(t, e.Level, log.InfoLevel)
+		assert.Equal(t, log.Fields{"file": "sloth.png"}, e.Fields)
+	}
+
+	{
+		e := h.Entries[1]
+		assert.Equal(t, e.Message, "upload")
+		assert.Equal(t, e.Level, log.InfoLevel)
+		assert.Equal(t, "sloth.png", e.Fields["file"])
+		assert.IsType(t, time.Duration(0), e.Fields["duration"])
+	}
+}
+
 func TestLogger_HandlerFunc(t *testing.T) {
 	h := memory.New()
 	f := func(e *log.Entry) error {


### PR DESCRIPTION
When no error is returned by the function being traced, allow a call like 

```go
defer log.Trace("starting").Stop(nil)
```