### PR TITLE
Allow WithError to be called with a nil error

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -42,6 +42,9 @@ func (e *Entry) WithField(key string, value interface{}) *Entry {
 
 // WithError returns a new entry with the "error" set to `err`.
 func (e *Entry) WithError(err error) *Entry {
+	if err == nil {
+		return e.WithField("error", err)
+	}
 	return e.WithField("error", err.Error())
 }
 

--- a/entry_test.go
+++ b/entry_test.go
@@ -36,4 +36,7 @@ func TestEntry_WithError(t *testing.T) {
 	b := a.WithError(fmt.Errorf("boom"))
 	assert.Equal(t, Fields{}, a.mergedFields())
 	assert.Equal(t, Fields{"error": "boom"}, b.mergedFields())
+
+	c := a.WithError(nil)
+	assert.Equal(t, Fields{"error": nil}, c.mergedFields())
 }


### PR DESCRIPTION
Fixed nil pointer error in WithError when err is nil.