### PR TITLE
Fix for fields getting corrupt

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -29,9 +29,12 @@ func NewEntry(log *Logger) *Entry {
 
 // WithFields returns a new entry with `fields` set.
 func (e *Entry) WithFields(fields Fielder) *Entry {
+	f := []Fields{}
+	f = append(f, e.fields...)
+	f = append(f, fields.Fields())
 	return &Entry{
 		Logger: e.Logger,
-		fields: append(e.fields, fields.Fields()),
+		fields: f,
 	}
 }
 


### PR DESCRIPTION
In some scenarios the fields object would get corrupt. Especially in multiple goroutines.

We cannot use native `append` as it actually modifies the original slice - in this scenario `e.fields` will get modified.

Here is a related SO article: http://stackoverflow.com/questions/35276022/unexpected-slice-append-behaviour which describes this behavior.