### PR TITLE
Add handling for parsing levels that are not input in all lowercase

### DIFF
--- a/levels.go
+++ b/levels.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"errors"
+	"strings"
 )
 
 // Level of severity.
@@ -36,7 +37,7 @@ func (l Level) MarshalJSON() ([]byte, error) {
 
 // ParseLevel parses level string.
 func ParseLevel(s string) (Level, error) {
-	switch s {
+	switch strings.ToLower(s) {
 	case "debug":
 		return DebugLevel, nil
 	case "info":

--- a/levels_test.go
+++ b/levels_test.go
@@ -21,6 +21,18 @@ func TestParseLevel(t *testing.T) {
 	}
 
 	{
+        level, err := ParseLevel("DEBUG")
+        assert.NoError(t, err)
+        assert.Equal(t, DebugLevel, level)
+    }
+
+    {
+        level, err := ParseLevel("Warning")
+        assert.NoError(t, err)
+        assert.Equal(t, WarnLevel, level)
+    }
+
+	{
 		_, err := ParseLevel("whatever")
 		assert.Error(t, err)
 	}


### PR DESCRIPTION
This PR simply lowercases the incoming value to `ParseLevel` so that strings such as `DEBUG` can be specified and properly mapped to their respective value.