### PR TITLE
Ensure WithError doesn't panic

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -48,7 +48,10 @@ func (e *Entry) WithField(key string, value interface{}) *Entry {
 
 // WithError returns a new entry with the "error" set to `err`.
 func (e *Entry) WithError(err error) *Entry {
-	return e.WithField("error", err.Error())
+	if err != nil {
+		return e.WithField("error", err.Error())
+	}
+	return e
 }
 
 // Debug level message.

--- a/entry_test.go
+++ b/entry_test.go
@@ -36,4 +36,7 @@ func TestEntry_WithError(t *testing.T) {
 	b := a.WithError(fmt.Errorf("boom"))
 	assert.Equal(t, Fields{}, a.mergedFields())
 	assert.Equal(t, Fields{"error": "boom"}, b.mergedFields())
+
+	c := a.WithError(nil)
+	assert.Equal(t, Fields{}, c.mergedFields())
 }


### PR DESCRIPTION
Hi there! I've been bitten a few times by accidentally passing a `nil` error to `WithError` and causing a panic 😢 

This patch modifies the behavior so that instead of panicking, you simply get the unmodified Entry back. Thanks!