### PR TITLE
Added custom rule Handler

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,6 +16,7 @@ Package log implements a simple structured logging API inspired by Logrus, desig
 - __memory__ – in-memory handler for tests
 - __multi__ – fan-out to multiple handlers
 - __papertrail__ – Papertrail handler
+- __rule__ - custom rule handler
 - __text__ – human-friendly colored output
 
 ## Badges

--- a/_examples/rule/rule.go
+++ b/_examples/rule/rule.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"github.com/apex/log"
+	"github.com/apex/log/handlers/cli"
+	"github.com/apex/log/handlers/rule"
+)
+
+func main() {
+	log.SetHandler(rule.New(cli.Default, func(entry *log.Entry) bool {
+		if entry.Fields.Get("internal") != nil {
+			return false
+		}
+
+		return true
+	}))
+
+	log.SetLevel(log.DebugLevel)
+
+	log.WithField("internal", "yup").Error("this won't go to log")
+
+	log.WithField("alice", "bob").Info("but this will")
+}

--- a/handlers/rule/rule.go
+++ b/handlers/rule/rule.go
@@ -30,7 +30,7 @@ func New(next log.Handler, rules ...Rule) *ruleHandler {
 }
 
 // Helper function that merges a set of Rules, returning a Rule which is
-// satisfied if at least one of underlying Rules is satisified.
+// satisfied if at least one of underlying Rules is satisfied.
 func Or(rules ...Rule) Rule {
 	return func(entry *log.Entry) bool {
 		for _, rule := range rules {

--- a/handlers/rule/rule.go
+++ b/handlers/rule/rule.go
@@ -1,0 +1,44 @@
+package rule
+
+import (
+	"github.com/apex/log"
+)
+
+// A Rule func returns if entry passes the rule.
+type Rule func(*log.Entry) bool
+
+type ruleHandler struct {
+	next  log.Handler
+	rules []Rule
+}
+
+// Implements log.Handler interface.
+func (rh *ruleHandler) HandleLog(entry *log.Entry) error {
+	for _, rule := range rh.rules {
+		if !rule(entry) {
+			return nil
+		}
+	}
+
+	return rh.next.HandleLog(entry)
+}
+
+// Constructs a RuleHandler which passes entries to next Handler
+// only if all Rules are satisfied.
+func New(next log.Handler, rules ...Rule) *ruleHandler {
+	return &ruleHandler{next, rules}
+}
+
+// Helper function that merges a set of Rules, returning a Rule which is
+// satisfied if at least one of underlying Rules is satisified.
+func Or(rules ...Rule) Rule {
+	return func(entry *log.Entry) bool {
+		for _, rule := range rules {
+			if rule(entry) {
+				return true
+			}
+		}
+
+		return false
+	}
+}


### PR DESCRIPTION
This Handler allows to filter certain log entries depending on i.e. certain field or some other circumstances. 

A real-life example is to filter some sensitive data from going to centralized logging server on production build, but allow it to go to CLI on dev's local machine for debugging purposes.

An ``Or`` function also provided to ease rule construction.