### PR TITLE
preserve Entry's internal vars when calling Entry.WithFields

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -37,8 +37,10 @@ func (e *Entry) WithFields(fields Fielder) *Entry {
 	f = append(f, e.fields...)
 	f = append(f, fields.Fields())
 	return &Entry{
-		Logger: e.Logger,
-		fields: f,
+		Logger:  e.Logger,
+		fields:  f,
+		start:   e.start,
+		Message: e.Message,
 	}
 }
 


### PR DESCRIPTION
This way, it's possible to do things like this:

```go
trace := log.Trace("test")
ret, err := handler()
if err != nil {
    trace = trace.WithFields(...custom fields just in case of error...)
}
trace.Stop(&err)
```