### PR TITLE
add WithFieldFunc() for dynamic fields at log invocation with fixed calldepth

### DIFF
--- a/entry_test.go
+++ b/entry_test.go
@@ -48,6 +48,19 @@ func TestEntry_WithErrorFields(t *testing.T) {
 	}, b.mergedFields())
 }
 
+func TestEntry_WithFieldFunc(t *testing.T) {
+	var foo = "test"
+	a := NewEntry(nil)
+	a = a.WithFieldFunc(func() Fielder {
+		return Fields{
+			"foo": foo,
+		}
+	})
+	foo = "bar"
+	a = a.applyFieldFuncs()
+	assert.Equal(t, Fields{"foo": "bar"}, a.mergedFields())
+}
+
 type errFields string
 
 func (ef errFields) Error() string {


### PR DESCRIPTION
Hi!

we've been scratching our heads for a way to implement line numbering in a non fragile way that won't break when new wrapper handlers are added, and this is what i've come up with. i appreciate i've changed quite a few things so i welcome feedback, or if you'd rather not that's fine too!

thanks

example line number implementation: 

```go
func GetAppLogContext() *alog.Entry {
	log := log.WithFieldFunc(func() alog.Fielder {
		_, file, line, ok := runtime.Caller(alog.FieldFuncCallDepth)
		if ok {
			return alog.Fields{
				"caller_file": file,
				"caller_line": strconv.Itoa(line),
			}
		}
		return nil
	})
	return log
}
```