### PR TITLE
simplify public interface - replace *Entry with Interface in interface.go

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -7,9 +7,6 @@ import (
 	"time"
 )
 
-// assert interface compliance.
-var _ Interface = (*Entry)(nil)
-
 // Now returns the current time.
 var Now = time.Now
 
@@ -32,7 +29,11 @@ func NewEntry(log *Logger) *Entry {
 }
 
 // WithFields returns a new entry with `fields` set.
-func (e *Entry) WithFields(fields Fielder) *Entry {
+func (e *Entry) WithFields(fields Fielder) Interface {
+	return e.withFields(fields)
+}
+
+func (e *Entry) withFields(fields Fielder) *Entry {
 	f := []Fields{}
 	f = append(f, e.fields...)
 	f = append(f, fields.Fields())
@@ -43,7 +44,7 @@ func (e *Entry) WithFields(fields Fielder) *Entry {
 }
 
 // WithField returns a new entry with the `key` and `value` set.
-func (e *Entry) WithField(key string, value interface{}) *Entry {
+func (e *Entry) WithField(key string, value interface{}) Interface {
 	return e.WithFields(Fields{key: value})
 }
 
@@ -51,7 +52,7 @@ func (e *Entry) WithField(key string, value interface{}) *Entry {
 //
 // The given error may implement .Fielder, if it does the method
 // will add all its `.Fields()` into the returned entry.
-func (e *Entry) WithError(err error) *Entry {
+func (e *Entry) WithError(err error) Interface {
 	ctx := e.WithField("error", err.Error())
 
 	if s, ok := err.(stackTracer); ok {
@@ -129,9 +130,9 @@ func (e *Entry) Fatalf(msg string, v ...interface{}) {
 
 // Trace returns a new entry with a Stop method to fire off
 // a corresponding completion log, useful with defer.
-func (e *Entry) Trace(msg string) *Entry {
+func (e *Entry) Trace(msg string) Interface {
 	e.Info(msg)
-	v := e.WithFields(e.Fields)
+	v := e.withFields(e.Fields)
 	v.Message = msg
 	v.start = time.Now()
 	return v

--- a/entry_test.go
+++ b/entry_test.go
@@ -13,9 +13,9 @@ func TestEntry_WithFields(t *testing.T) {
 
 	b := a.WithFields(Fields{"foo": "bar"})
 	assert.Equal(t, Fields{}, a.mergedFields())
-	assert.Equal(t, Fields{"foo": "bar"}, b.mergedFields())
+	assert.Equal(t, Fields{"foo": "bar"}, b.(*Entry).mergedFields())
 
-	c := a.WithFields(Fields{"foo": "hello", "bar": "world"})
+	c := a.WithFields(Fields{"foo": "hello", "bar": "world"}).(*Entry)
 
 	e := c.finalize(InfoLevel, "upload")
 	assert.Equal(t, e.Message, "upload")
@@ -28,19 +28,19 @@ func TestEntry_WithField(t *testing.T) {
 	a := NewEntry(nil)
 	b := a.WithField("foo", "bar")
 	assert.Equal(t, Fields{}, a.mergedFields())
-	assert.Equal(t, Fields{"foo": "bar"}, b.mergedFields())
+	assert.Equal(t, Fields{"foo": "bar"}, b.(*Entry).mergedFields())
 }
 
 func TestEntry_WithError(t *testing.T) {
 	a := NewEntry(nil)
 	b := a.WithError(fmt.Errorf("boom"))
 	assert.Equal(t, Fields{}, a.mergedFields())
-	assert.Equal(t, Fields{"error": "boom"}, b.mergedFields())
+	assert.Equal(t, Fields{"error": "boom"}, b.(*Entry).mergedFields())
 }
 
 func TestEntry_WithErrorFields(t *testing.T) {
 	a := NewEntry(nil)
-	b := a.WithError(errFields("boom"))
+	b := a.WithError(errFields("boom")).(*Entry)
 	assert.Equal(t, Fields{}, a.mergedFields())
 	assert.Equal(t, Fields{
 		"error":  "boom",

--- a/interface.go
+++ b/interface.go
@@ -2,9 +2,9 @@ package log
 
 // Interface represents the API of both Logger and Entry.
 type Interface interface {
-	WithFields(fields Fielder) *Entry
-	WithField(key string, value interface{}) *Entry
-	WithError(err error) *Entry
+	WithFields(fields Fielder) Interface
+	WithField(key string, value interface{}) Interface
+	WithError(err error) Interface
 	Debug(msg string)
 	Info(msg string)
 	Warn(msg string)
@@ -15,5 +15,5 @@ type Interface interface {
 	Warnf(msg string, v ...interface{})
 	Errorf(msg string, v ...interface{})
 	Fatalf(msg string, v ...interface{})
-	Trace(msg string) *Entry
+	Trace(msg string) Interface
 }

--- a/logger.go
+++ b/logger.go
@@ -5,9 +5,6 @@ import (
 	"sort"
 )
 
-// assert interface compliance.
-var _ Interface = (*Logger)(nil)
-
 // Fielder is an interface for providing fields to custom types.
 type Fielder interface {
 	Fields() Fields
@@ -62,7 +59,7 @@ type Logger struct {
 }
 
 // WithFields returns a new entry with `fields` set.
-func (l *Logger) WithFields(fields Fielder) *Entry {
+func (l *Logger) WithFields(fields Fielder) Interface {
 	return NewEntry(l).WithFields(fields.Fields())
 }
 
@@ -70,12 +67,12 @@ func (l *Logger) WithFields(fields Fielder) *Entry {
 //
 // Note that the `key` should not have spaces in it - use camel
 // case or underscores
-func (l *Logger) WithField(key string, value interface{}) *Entry {
+func (l *Logger) WithField(key string, value interface{}) Interface {
 	return NewEntry(l).WithField(key, value)
 }
 
 // WithError returns a new entry with the "error" set to `err`.
-func (l *Logger) WithError(err error) *Entry {
+func (l *Logger) WithError(err error) Interface {
 	return NewEntry(l).WithError(err)
 }
 
@@ -131,7 +128,7 @@ func (l *Logger) Fatalf(msg string, v ...interface{}) {
 
 // Trace returns a new entry with a Stop method to fire off
 // a corresponding completion log, useful with defer.
-func (l *Logger) Trace(msg string) *Entry {
+func (l *Logger) Trace(msg string) Interface {
 	return NewEntry(l).Trace(msg)
 }
 

--- a/pkg.go
+++ b/pkg.go
@@ -29,17 +29,17 @@ func SetLevelFromString(s string) {
 }
 
 // WithFields returns a new entry with `fields` set.
-func WithFields(fields Fielder) *Entry {
+func WithFields(fields Fielder) Interface {
 	return Log.WithFields(fields)
 }
 
 // WithField returns a new entry with the `key` and `value` set.
-func WithField(key string, value interface{}) *Entry {
+func WithField(key string, value interface{}) Interface {
 	return Log.WithField(key, value)
 }
 
 // WithError returns a new entry with the "error" set to `err`.
-func WithError(err error) *Entry {
+func WithError(err error) Interface {
 	return Log.WithError(err)
 }
 
@@ -95,6 +95,6 @@ func Fatalf(msg string, v ...interface{}) {
 
 // Trace returns a new entry with a Stop method to fire off
 // a corresponding completion log, useful with defer.
-func Trace(msg string) *Entry {
+func Trace(msg string) Interface {
 	return Log.Trace(msg)
 }


### PR DESCRIPTION
Hello!

In the spirit of simplifying the logrus API, this PR replaces `*Entry` in the public interface to be `Interface`.  Most of the changes were mechanical in nature (it just worked).   One private helper function was needed in Entry (near trivial).  Some casts were needed in the tests. 

Totally understand if you don't merge,since this is a semver API change.   But if you are interested in a v2, I think interface.go can become completely self-contained.  This would step 1 to do so.

Thanks for an interesting project!

n

```
 type Interface interface {		 
	WithFields(fields Fielder) *Entry
	WithField(key string, value interface{}) *Entry
	WithError(err error) *Entry
(and others)
```

After:

```go
type Interface interface {
  WithFields(fields Fielder) Interface
  WithField(key string, value interface{}) Interface
  WithError(err error) Interface
// (and others)
}
```