### PR TITLE
handlers/cli: Show non-string fields appropriately

### DIFF
--- a/handlers/cli/cli.go
+++ b/handlers/cli/cli.go
@@ -76,7 +76,7 @@ func (h *Handler) HandleLog(e *log.Entry) error {
 		if name == "source" {
 			continue
 		}
-		fmt.Fprintf(h.Writer, " %s=%s", color.Sprint(name), e.Fields.Get(name))
+		fmt.Fprintf(h.Writer, " %s=%v", color.Sprint(name), e.Fields.Get(name))
 	}
 
 	fmt.Fprintln(h.Writer)


### PR DESCRIPTION
Before:

`   • Saved     bytes=%!s(int=95)`

After:

`   • Saved     bytes=95`

This is the [same behavior as handlers/text](https://github.com/apex/log/blob/master/handlers/text/text.go#L74).