### PR TITLE
allow users to create Levels directly from integers

### DIFF
--- a/levels.go
+++ b/levels.go
@@ -79,3 +79,12 @@ func MustParseLevel(s string) Level {
 
 	return l
 }
+
+// FromInt validates level integers.
+func FromInt(i int) (Level, error) {
+	if i < 0 || i >= len(levelNames) {
+		return InvalidLevel, ErrInvalidLevel
+	}
+
+	return levelStrings[levelNames[i]]
+}

--- a/levels.go
+++ b/levels.go
@@ -86,5 +86,5 @@ func FromInt(i int) (Level, error) {
 		return InvalidLevel, ErrInvalidLevel
 	}
 
-	return levelStrings[levelNames[i]]
+	return levelStrings[levelNames[i]], nil
 }


### PR DESCRIPTION
If users want to create a `log.Level` directly from an integer they need to wait for `log.SetLevel` to fail or write their own checks for whether a log level integer is valid. Instead we could provide `FromInt`  to do this work upstream where it has access to package-private `levelStrings` and `levelNames` 