### PR TITLE
add WithTraceAt() method to adjust Trace() log level

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -7,6 +7,7 @@ type Interface interface {
 	WithFields(Fielder) *Entry
 	WithField(string, interface{}) *Entry
 	WithDuration(time.Duration) *Entry
+	WithTraceAt(Level) *Entry
 	WithError(error) *Entry
 	Debug(string)
 	Info(string)

--- a/logger.go
+++ b/logger.go
@@ -86,6 +86,12 @@ func (l *Logger) WithError(err error) *Entry {
 	return NewEntry(l).WithError(err)
 }
 
+// WithTraceAt returns a new entry with Trace() and Stop() methods
+// that log non-errors at the requested level.
+func (l *Logger) WithTraceAt(level Level) *Entry {
+	return NewEntry(l).WithTraceAt(level)
+}
+
 // Debug level message.
 func (l *Logger) Debug(msg string) {
 	NewEntry(l).Debug(msg)

--- a/logger_test.go
+++ b/logger_test.go
@@ -176,6 +176,99 @@ func TestLogger_Trace_nil(t *testing.T) {
 	}
 }
 
+func TestLogger_WithTraceAt_Trace_level(t *testing.T) {
+	h := memory.New()
+
+	l := &log.Logger{
+		Handler: h,
+		Level:   log.DebugLevel,
+	}
+
+	func() (err error) {
+		defer l.WithField("file", "sloth.png").WithTraceAt(log.DebugLevel).Trace("upload").Stop(&err)
+		return nil
+	}()
+
+	assert.Equal(t, 2, len(h.Entries))
+
+	{
+		e := h.Entries[0]
+		assert.Equal(t, e.Message, "upload")
+		assert.Equal(t, e.Level, log.DebugLevel)
+		assert.Equal(t, log.Fields{"file": "sloth.png"}, e.Fields)
+	}
+
+	{
+		e := h.Entries[1]
+		assert.Equal(t, e.Message, "upload")
+		assert.Equal(t, e.Level, log.DebugLevel)
+		assert.Equal(t, "sloth.png", e.Fields["file"])
+		assert.IsType(t, int64(0), e.Fields["duration"])
+	}
+}
+
+func TestLogger_WithTraceAt_Trace_err(t *testing.T) {
+	h := memory.New()
+
+	l := &log.Logger{
+		Handler: h,
+		Level:   log.DebugLevel,
+	}
+
+	func() (err error) {
+		defer l.WithField("file", "sloth.png").WithTraceAt(log.DebugLevel).Trace("upload").Stop(&err)
+		return fmt.Errorf("boom")
+	}()
+
+	assert.Equal(t, 2, len(h.Entries))
+
+	{
+		e := h.Entries[0]
+		assert.Equal(t, e.Message, "upload")
+		assert.Equal(t, e.Level, log.DebugLevel)
+		assert.Equal(t, "sloth.png", e.Fields["file"])
+	}
+
+	{
+		e := h.Entries[1]
+		assert.Equal(t, e.Message, "upload")
+		assert.Equal(t, e.Level, log.ErrorLevel)
+		assert.Equal(t, "sloth.png", e.Fields["file"])
+		assert.Equal(t, "boom", e.Fields["error"])
+		assert.IsType(t, int64(0), e.Fields["duration"])
+	}
+}
+
+func TestLogger_WithTraceAt_Trace_nil(t *testing.T) {
+	h := memory.New()
+
+	l := &log.Logger{
+		Handler: h,
+		Level:   log.DebugLevel,
+	}
+
+	func() {
+		defer l.WithField("file", "sloth.png").WithTraceAt(log.DebugLevel).Trace("upload").Stop(nil)
+	}()
+
+	assert.Equal(t, 2, len(h.Entries))
+
+	{
+		e := h.Entries[0]
+		assert.Equal(t, e.Message, "upload")
+		assert.Equal(t, e.Level, log.DebugLevel)
+		assert.Equal(t, log.Fields{"file": "sloth.png"}, e.Fields)
+	}
+
+	{
+		e := h.Entries[1]
+		assert.Equal(t, e.Message, "upload")
+		assert.Equal(t, e.Level, log.DebugLevel)
+		assert.Equal(t, "sloth.png", e.Fields["file"])
+		assert.IsType(t, int64(0), e.Fields["duration"])
+	}
+}
+
 func TestLogger_HandlerFunc(t *testing.T) {
 	h := memory.New()
 	f := func(e *log.Entry) error {

--- a/pkg.go
+++ b/pkg.go
@@ -51,6 +51,12 @@ func WithError(err error) *Entry {
 	return Log.WithError(err)
 }
 
+// WithTraceAt returns a new entry with Trace() and Stop() methods
+// that log non-errors at the requested level.
+func WithTraceAt(level Level) *Entry {
+	return Log.WithTraceAt(level)
+}
+
 // Debug level message.
 func Debug(msg string) {
 	Log.Debug(msg)


### PR DESCRIPTION
Hey @tj!  I'm loving Apex's `log` module so far, and figured I'd take a crack at adding a method to allow `.Trace()` and `.Stop()` to log non-errors at a configurable level. I'm happy to rename that method as well &mdash; let me know what feels right to you :)

-----

The Trace() and Stop() methods for an Entry default to Info-level logging, and previously didn't offer a way to log non-errors at any other level. Add a WithTraceAt() method to allow that level to be configured.

fixes #93