### PR TITLE
Fix concurrency issue by copying map of Fields

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -17,9 +17,15 @@ type Fielder interface {
 // Fields represents a map of entry level data used for structured logging.
 type Fields map[string]interface{}
 
-// Fields implements Fielder.
+// Fields implements Fielder, returning a shallow copy of Fields.
+// This is to prevent runtime error that happens when we read and
+// write a map at the same time.
 func (f Fields) Fields() Fields {
-	return f
+	res := map[string]interface{}{}
+	for k, v := range f {
+		res[k] = v
+	}
+	return res
 }
 
 // Get field value by name.


### PR DESCRIPTION
Hello, 

Opening this PR to fix issue #74 if you are open to contribution. Basically this PR is taking suggestion from the issue:

> Perhaps func (f Fields) Fields() Fields should make a shallow copy of the underlying map instead of just returning the Fields struct?

Alongside with unit test to demonstrate the issue and that it's fixed. 

Let me know if there's something to improve. Thanks!